### PR TITLE
Remove deprecated method from field type example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ class PurifiedTextareaType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->appendClientTransformer($this->purifierTransformer);
+        $builder->addViewTransformer($this->purifierTransformer);
     }
 
     public function getParent()


### PR DESCRIPTION
The method appendClientTransformer is deprecated since Symfony 2.1 and will be removed in 2.3.
