### PR TITLE
Added the branch alias for master and fixed requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,12 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "ezyang/htmlpurifier": "~4"
+        "ezyang/htmlpurifier": "~4.0"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
     },
     "autoload": {
         "psr-0": { "Exercise\\HTMLPurifierBundle": "" }


### PR DESCRIPTION
`~4` means `>=4,<+INF` as it allows bumping the major version. I don't think it is a good idea in this case.

Releasing a 1.0 tag would also be good as it would make the bundle friendlier for people using `minimum-stability: stable` (which is the case by default in the SE as of 2.3)
