### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,7 @@ class PurifiedTextareaType extends AbstractType
 }
 ```
 
-Additionally, we can define both the field type and transformer in the service
-container:
+Then define both the field type and transformer in the service container:
 
 ``` xml
 <services>


### PR DESCRIPTION
Add instructions to install with composer - using `git submodule` to install is a really outdated method, although I've left it in case it is needed for Symfony 2.0 or something.

Also changed "Additionally, we can" to "Then" as it is something you need to do, not something that is optional, if you are using the form data transformer (as far as I can tell)
