### PR TITLE
no need to bootstrap HTML Purifier when using composer autoloader.

### DIFF
--- a/ExerciseHTMLPurifierBundle.php
+++ b/ExerciseHTMLPurifierBundle.php
@@ -6,8 +6,4 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ExerciseHTMLPurifierBundle extends Bundle
 {
-    public function boot()
-    {
-        new \HTMLPurifier_Bootstrap();
-    }
 }


### PR DESCRIPTION
Now that [HTML Purifier complies with PSR-0](https://github.com/ezyang/htmlpurifier/commit/344e0640b6610883a0aa6766cc6750d26d091c76), it's not longer necessary to bootstrap the library in the bundle's boot method.