### PR TITLE
use PSR-4 autoloading.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         }
     },
     "autoload": {
-        "psr-0": { "Exercise\\HTMLPurifierBundle": "" }
-    },
-    "target-dir": "Exercise/HTMLPurifierBundle"
+        "psr-4": { "Exercise\\HTMLPurifierBundle\\": "" }
+    }
 }


### PR DESCRIPTION
This flattens out the directory structure in `vendor` (and closes out all my reasons for forking this bundle).
