### PR TITLE
Switch the Twig integration to use non-deprecated APIs

### DIFF
--- a/Twig/HTMLPurifierExtension.php
+++ b/Twig/HTMLPurifierExtension.php
@@ -26,7 +26,7 @@ class HTMLPurifierExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'purify' => new \Twig_Filter_Method($this, 'purify', array('is_safe' => array('html'))),
+            new \Twig_SimpleFilter('purify', array($this, 'purify'), array('is_safe' => array('html'))),
         );
     }
 


### PR DESCRIPTION
This makes the bundle compatible with Twig 2.0 and avoids the deprecation warning in 1.21+