### PR TITLE
Twig 1.12 must be the minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "symfony/form": "~2.0",
-        "twig/twig": "~1.3"
+        "twig/twig": "~1.12"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
The new Twig [API](https://github.com/Exercise/HTMLPurifierBundle/commit/95e8516ae3a87a30d0f084237b0ead24f18eaba7) was introduced with 1.12