### PR TITLE
build cache in warmer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 phpunit.xml
+composer.lock
+vendor/

--- a/CacheWarmer/SerializerCacheWarmer.php
+++ b/CacheWarmer/SerializerCacheWarmer.php
@@ -3,6 +3,7 @@
 namespace Exercise\HTMLPurifierBundle\CacheWarmer;
 
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use HTMLPurifier;
 
 /**
  * Cache warmer for creating HTMLPurifier's cache directory.
@@ -18,9 +19,10 @@ class SerializerCacheWarmer implements CacheWarmerInterface
      *
      * @param array $paths
      */
-    public function __construct(array $paths)
+    public function __construct(array $paths, HTMLPurifier $htmlPurifier)
     {
         $this->paths = $paths;
+        $this->htmlPurifier = $htmlPurifier;
     }
 
     /**
@@ -37,6 +39,8 @@ class SerializerCacheWarmer implements CacheWarmerInterface
                 throw new \RuntimeException(sprintf('The HTMLPurifier Serializer cache directory "%s" is not writeable for the current system user.', $path));
             }
         }
+        $this->htmlPurifier->purify('<div style="border: thick">-2</div>');
+        $this->htmlPurifier->purify('<div style="background:url(\'http://www.example.com/x.gif\');">');
     }
 
     /**

--- a/CacheWarmer/SerializerCacheWarmer.php
+++ b/CacheWarmer/SerializerCacheWarmer.php
@@ -6,13 +6,20 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use HTMLPurifier;
 
 /**
- * Cache warmer for creating HTMLPurifier's cache directory.
+ * Cache warmer for creating HTMLPurifier's cache directory and contents.
  *
+ * Run purify() with various contents to have the caches built here, and not
+ * on first use, as the owning user may be different then, causing problems
+ * with file ownership when deleting the cached files later.
+ * 
  * @author Henrik Bjornskov <henrik@bjrnskov.dk>
  */
 class SerializerCacheWarmer implements CacheWarmerInterface
 {
     private $paths;
+
+    /** @var HTMLPurifier used to build cache within bundle runtime */
+    private $htmlPurifier;
 
     /**
      * Constructor.
@@ -39,6 +46,8 @@ class SerializerCacheWarmer implements CacheWarmerInterface
                 throw new \RuntimeException(sprintf('The HTMLPurifier Serializer cache directory "%s" is not writeable for the current system user.', $path));
             }
         }
+
+        // build htmlPurifier cache for HTML/CSS & URIs with the other Symfony cache warmups. Fixes issue #22
         $this->htmlPurifier->purify('<div style="border: thick">-2</div>');
         $this->htmlPurifier->purify('<div style="background:url(\'http://www.example.com/x.gif\');">');
     }

--- a/Resources/config/html_purifier.xml
+++ b/Resources/config/html_purifier.xml
@@ -15,6 +15,7 @@
     <services>
         <service id="exercise_html_purifier.cache_warmer.serializer" class="%exercise_html_purifier.cache_warmer.serializer.class%">
             <argument>%exercise_html_purifier.cache_warmer.serializer.paths%</argument>
+            <argument type="service" id="exercise_html_purifier.default" />
             <tag name="kernel.cache_warmer" />
         </service>
 

--- a/Tests/CacheWarmer/SerializerCacheWarmerTest.php
+++ b/Tests/CacheWarmer/SerializerCacheWarmerTest.php
@@ -8,7 +8,7 @@ class SerializerCacheWarmerTest extends \PHPUnit_Framework_TestCase
 {
     public function testShouldBeRequired()
     {
-        $cacheWarmer = new SerializerCacheWarmer(array());
+        $cacheWarmer = new SerializerCacheWarmer(array(), new \HTMLPurifier());
         $this->assertFalse($cacheWarmer->isOptional());
     }
 
@@ -20,7 +20,7 @@ class SerializerCacheWarmerTest extends \PHPUnit_Framework_TestCase
 
         $path = sys_get_temp_dir() . '/' . uniqid('htmlpurifierbundle');
 
-        $cacheWarmer = new SerializerCacheWarmer(array($path));
+        $cacheWarmer = new SerializerCacheWarmer(array($path), new \HTMLPurifier());
         $cacheWarmer->warmUp(null);
 
         $this->assertTrue(is_dir($path));


### PR DESCRIPTION
Fixes #22. Has the files generated by the deployment user, like the rest of  the initial cache build, instead of the web-server user on first use.