### PR TITLE
Make the exercise_html_purifier.$name service public

### DIFF
--- a/DependencyInjection/ExerciseHTMLPurifierExtension.php
+++ b/DependencyInjection/ExerciseHTMLPurifierExtension.php
@@ -73,7 +73,7 @@ class ExerciseHTMLPurifierExtension extends Extension
             $container->setDefinition(
                 'exercise_html_purifier.' . $name,
                 new Definition('%exercise_html_purifier.class%', array(new Reference($configId)))
-            );
+            )->setPublic(true);
 
             if (isset($config['Cache.SerializerPath'])) {
                 $paths[] = $config['Cache.SerializerPath'];

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.0|~3.0",
-        "ezyang/htmlpurifier": "~4.0"
+        "symfony/framework-bundle": "^2.0 || ^3.0 || ^4.0",
+        "ezyang/htmlpurifier": "^4.0"
     },
     "require-dev": {
-        "symfony/form": "~2.0",
-        "twig/twig": "~1.3|~2.0"
+        "symfony/form": "^2.0 || ^3.0 || ^4.0",
+        "twig/twig": "^1.3 || ^2.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
In Symfony > 3.4 services have to be public to be fetched from the container.
Getting private services is deprecated since 3.2 and was removed in 4.0.