### PR TITLE
Fixed exception when using TextType without purify options

### DIFF
--- a/Form/TypeExtension/HTMLPurifierTextTypeExtension.php
+++ b/Form/TypeExtension/HTMLPurifierTextTypeExtension.php
@@ -39,7 +39,7 @@ class HTMLPurifierTextTypeExtension extends AbstractTypeExtension
                 'purify_html_profile' => 'default',
             ])
             ->setAllowedTypes('purify_html', 'bool')
-            ->setAllowedTypes('purify_html_profile', 'string')
+            ->setAllowedTypes('purify_html_profile', ['string', 'null'])
             ->setNormalizer('purify_html_profile', function (Options $options, $profile) {
                 if (!$options['purify_html']) {
                     return null;


### PR DESCRIPTION
Fixes exception 

> The option "purify_html_profile" with value null is expected to be of type "string", but is of type "NULL"

 when using TextType without specifying any purify options.