### PR TITLE
Implement static function getExtendedTypes(): iterable in place of getExtendedType

### DIFF
--- a/Form/TypeExtension/HTMLPurifierTextTypeExtension.php
+++ b/Form/TypeExtension/HTMLPurifierTextTypeExtension.php
@@ -23,9 +23,9 @@ class HTMLPurifierTextTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function getExtendedType()
+    public static function getExtendedTypes(): iterable
     {
-        return TextType::class;
+        return [TextType::class];
     }
 
     /**

--- a/Form/TypeExtension/HTMLPurifierTextTypeExtension.php
+++ b/Form/TypeExtension/HTMLPurifierTextTypeExtension.php
@@ -23,6 +23,14 @@ class HTMLPurifierTextTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
+    public function getExtendedType()
+    {
+        return TextType::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public static function getExtendedTypes(): iterable
     {
         return [TextType::class];

--- a/Form/TypeExtension/HTMLPurifierTextTypeExtension.php
+++ b/Form/TypeExtension/HTMLPurifierTextTypeExtension.php
@@ -31,7 +31,7 @@ class HTMLPurifierTextTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public static function getExtendedTypes(): iterable
+    public static function getExtendedTypes()
     {
         return [TextType::class];
     }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         { "name": "contributors", "homepage": "https://github.com/Exercise/HTMLPurifierBundle/contributors" }
     ],
     "require": {
-        "php": "^5.5.9|>=7.0.8",
+        "php": "^7.1.3",
         "ezyang/htmlpurifier": "~4.0",
         "symfony/dependency-injection": "~3.4.1 || ^4.0.1",
         "symfony/http-kernel": "~3.4.1 || ^4.0.1",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         { "name": "contributors", "homepage": "https://github.com/Exercise/HTMLPurifierBundle/contributors" }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^5.5.9|>=7.0.8",
         "ezyang/htmlpurifier": "~4.0",
         "symfony/dependency-injection": "~3.4.1 || ^4.0.1",
         "symfony/http-kernel": "~3.4.1 || ^4.0.1",


### PR DESCRIPTION
This PR fix this deprecation since Symfony 4.2

> Not implementing the static getExtendedTypes() method in Exercise\HTMLPurifierBundle\Form\TypeExtension\HTMLPurifierTextTypeExtension when implementing the Symfony\Component\Form\FormTypeExtensionInterface is deprecated since Symfony 4.2. The method will be added to the interface in 5.0.

```php
<?php
namespace Symfony\Component\Form;

use Symfony\Component\OptionsResolver\OptionsResolver;

/**
 * @author Bernhard Schussek <bschussek@gmail.com>
 *
 * @method static iterable getExtendedTypes() Gets the extended types - not implementing it is deprecated since Symfony 4.2
 */
interface FormTypeExtensionInterface
{
    //...

       /**
     * Returns the name of the type being extended.
     *
     * @return string The name of the type being extended
     *
     * @deprecated since Symfony 4.2, use getExtendedTypes() instead.
     */
    public function getExtendedType();
}
```