### PR TITLE
Support for Symfony 5 & Twig 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 php:
     - '7.1'
+    - '7.2'
+    - '7.3'
+    - '7.4snapshot'
 install: composer install
 script: php vendor/bin/phpunit

--- a/Form/TypeExtension/HTMLPurifierTextTypeExtension.php
+++ b/Form/TypeExtension/HTMLPurifierTextTypeExtension.php
@@ -23,15 +23,7 @@ class HTMLPurifierTextTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function getExtendedType()
-    {
-        return TextType::class;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function getExtendedTypes()
+    public static function getExtendedTypes(): iterable
     {
         return [TextType::class];
     }

--- a/Tests/Form/TypeExtension/HTMLPurifierTextTypeExtensionTest.php
+++ b/Tests/Form/TypeExtension/HTMLPurifierTextTypeExtensionTest.php
@@ -14,7 +14,7 @@ class HTMLPurifierTextTypeExtensionTest extends FormIntegrationTestCase
 {
     private $registry;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->registry = $this->createMock(HTMLPurifiersRegistryInterface::class);
 

--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,16 @@
         { "name": "contributors", "homepage": "https://github.com/Exercise/HTMLPurifierBundle/contributors" }
     ],
     "require": {
-        "php": "^5.5.9|>=7.0.8",
+        "php": "^7.1.3",
         "ezyang/htmlpurifier": "~4.0",
-        "symfony/dependency-injection": "~3.4.1 || ^4.0.1",
-        "symfony/http-kernel": "~3.4.1 || ^4.0.1",
-        "symfony/config": "~3.3 || ~4.0"
+        "symfony/dependency-injection": "^4.2 || ^5.0",
+        "symfony/http-kernel": "^4.2 || ^5.0",
+        "symfony/config": "^4.2 || ^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.2",
-        "symfony/form": "~3.4.1 || ^4.0.1",
-        "twig/twig": "^1.34.4 || ^2.4.3"
+        "symfony/form": "^4.2 || ^5.0",
+        "twig/twig": "^1.34.4 || ^2.4.3 || ^3.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
- Update minimum PHP to ^7.1.3
- Update Composer constraints
  - Drop Symfony ^3
  - Raise Symfony 4 to ^4.2
  - Add Symfony ^5.0
  - Add Twig ^3.0
- Add required type hints
- Add 7.2, 7.3 & 7.4 to Travis build