### PR TITLE
Replace eval by require_once in ForwardCompatTypeExtensionTrait

### DIFF
--- a/src/Form/TypeExtension/ForwardCompatTypeExtensionTrait.php
+++ b/src/Form/TypeExtension/ForwardCompatTypeExtensionTrait.php
@@ -5,24 +5,7 @@ namespace Exercise\HTMLPurifierBundle\Form\TypeExtension;
 use Symfony\Component\Form\FormTypeExtensionInterface;
 
 if (method_exists(FormTypeExtensionInterface::class, 'getExtendedTypes')) {
-    eval('
-    namespace Exercise\HTMLPurifierBundle\Form\TypeExtension;
-
-    /**
-     * @internal
-     */
-    trait ForwardCompatTypeExtensionTrait
-    {
-        private static function doGetExtendedTypes(): iterable
-        {
-        }
-
-        public static function getExtendedTypes(): iterable
-        {
-            return self::doGetExtendedTypes();
-        }
-    }
-');
+    require_once __DIR__.'/forward_compat_trait.inc.php';
 } else {
     /**
      * @internal

--- a/src/Form/TypeExtension/forward_compat_trait.inc.php
+++ b/src/Form/TypeExtension/forward_compat_trait.inc.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Exercise\HTMLPurifierBundle\Form\TypeExtension;
+
+/**
+ * @internal
+ */
+trait ForwardCompatTypeExtensionTrait
+{
+    private static function doGetExtendedTypes(): iterable
+    {
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return self::doGetExtendedTypes();
+    }
+}


### PR DESCRIPTION
When an application use the ForwardCompatTypeExtensionTrait trait with return types, an error is triggered since the Symfony container can't determine and include the file that created the trait:

`Warning: include_once(/var/www/html/vendor/exercise/html-purifier-bundle/src/Form/TypeExtension/ForwardCompatTypeExtensionTrait.php(8) : eval()'d code): failed to open stream: No such file or directory`

This PR aims to fix this issue.