### PR TITLE
Add support of the Cache.SerializerPermissions for default profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ had specified the following configuration:
 
 exercise_html_purifier:
     default_cache_serializer_path: '%kernel.cache_dir%/htmlpurifier'
+    # 493 int => ocl "0755"
+    default_cache_serializer_permissions: 493
 ```
 
 The `default` profile is special, it is *always* defined and its configuration

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,6 +21,10 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('default_cache_serializer_path')
                     ->defaultValue('%kernel.cache_dir%/htmlpurifier')
                 ->end()
+                ->scalarNode('default_cache_serializer_permissions')
+                    // (format "%#o" 493) "0755"
+                    ->defaultValue(493)
+                ->end()
                 ->arrayNode('html_profiles')
                     ->useAttributeAsKey('name')
                     ->normalizeKeys(false)

--- a/src/DependencyInjection/ExerciseHTMLPurifierExtension.php
+++ b/src/DependencyInjection/ExerciseHTMLPurifierExtension.php
@@ -27,6 +27,7 @@ class ExerciseHTMLPurifierExtension extends Extension
 
         // Set default serializer cache path, while ensuring a default profile is defined
         $configs['html_profiles']['default']['config']['Cache.SerializerPath'] = $configs['default_cache_serializer_path'];
+        $configs['html_profiles']['default']['config']['Cache.SerializerPermissions'] = $configs['default_cache_serializer_permissions'];
 
         $serializerPaths = [];
         // Drop when require Symfony > 3.4

--- a/tests/DependencyInjection/ExerciseHTMLPurifierExtensionTest.php
+++ b/tests/DependencyInjection/ExerciseHTMLPurifierExtensionTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\Reference;
 class ExerciseHTMLPurifierExtensionTest extends TestCase
 {
     private const DEFAULT_CACHE_PATH = '%kernel.cache_dir%/htmlpurifier';
+    private const DEFAULT_CACHE_PERMISSIONS = 493;
 
     /**
      * @var ContainerBuilder|null
@@ -38,6 +39,7 @@ class ExerciseHTMLPurifierExtensionTest extends TestCase
         $this->extension = new ExerciseHTMLPurifierExtension();
         $this->defaultConfig = [
             'Cache.SerializerPath' => self::DEFAULT_CACHE_PATH,
+            'Cache.SerializerPermissions' => self::DEFAULT_CACHE_PERMISSIONS,
         ];
     }
 
@@ -121,6 +123,31 @@ class ExerciseHTMLPurifierExtensionTest extends TestCase
 
         $this->assertDefaultConfigDefinition(array_merge($config['html_profiles']['default']['config'], [
             'Cache.SerializerPath' => null,
+            'Cache.SerializerPermissions' => 493,
+        ]));
+        $this->assertCacheWarmerSerializerArgs([], ['default']);
+        $this->assertRegistryHasProfiles(['default']);
+    }
+
+    public function testShouldAllowOverridingDefaultConfigurationCacheSerializerPermissions(): void
+    {
+        $config = [
+            'default_cache_serializer_path' => null,
+            'default_cache_serializer_permissions' => 511,
+            'html_profiles'                 => [
+                'default' => [
+                    'config' => [
+                        'AutoFormat.AutoParagraph' => true,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->extension->load([$config], $this->container);
+
+        $this->assertDefaultConfigDefinition(array_merge($config['html_profiles']['default']['config'], [
+            'Cache.SerializerPath' => null,
+            'Cache.SerializerPermissions' => 511,
         ]));
         $this->assertCacheWarmerSerializerArgs([], ['default']);
         $this->assertRegistryHasProfiles(['default']);


### PR DESCRIPTION
Allow to setup default file permissions for [HTMLPurifier](https://github.com/Exercise/HTMLPurifierBundle). 
See configuration in [docs](http://htmlpurifier.org/live/configdoc/plain.html#Cache.SerializerPermissions).

**Note**: SerializerPermissions must be set as integer that will be converted to correct chmod permissions. Example: 493 int => 0755 oct and 511 int => 0777 oct