### PR TITLE
drop support for unmaintained Symfony versions

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php-versions: ['7.1', '8.1']
+        php-versions: ['7.4', '8.1', '8.2']
 
     steps:
       - name: Checkout
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php-versions: ['7.1', '8.1']
+        php-versions: ['7.4', '8.1', '8.2']
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
         }
     ],
     "require": {
-        "php": "^7.1.3 || ^8.0.0",
+        "php": "^7.4 || ^8.0",
         "ezyang/htmlpurifier": "~4.14",
-        "symfony/config": "~4.4 || ^5.0 || ^6.0",
-        "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
-        "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0"
+        "symfony/config": "^5.4 || ^6.2",
+        "symfony/dependency-injection": "^5.4 || ^6.2",
+        "symfony/http-kernel": "^5.4 || ^6.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "symfony/form": "^4.4 || ^5.0 || ^6.0",
-        "symfony/phpunit-bridge": "^6.0",
+        "symfony/form": "^5.4 || ^6.2",
+        "symfony/phpunit-bridge": "^6.3",
         "twig/twig": "^1.35.0 || ^2.4.4 || ^3.0"
     },
     "autoload": {


### PR DESCRIPTION
See https://symfony.com/releases

4.4, 6.0 and 6.1 are not maintained anymore. Also drops support for PHP < 7.4.