### PR TITLE
update to latest action version

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP, extensions and composer with shivammathur/setup-php
         uses: shivammathur/setup-php@v2
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP, extensions and composer with shivammathur/setup-php
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "symfony/form": "^5.4 || ^6.0 || ^7.0",
-        "symfony/phpunit-bridge": "^7.0",
+        "symfony/phpunit-bridge": "^7.0.1",
         "twig/twig": "^2.4.4 || ^3.0"
     },
     "autoload": {

--- a/src/CacheWarmer/SerializerCacheWarmer.php
+++ b/src/CacheWarmer/SerializerCacheWarmer.php
@@ -37,7 +37,7 @@ class SerializerCacheWarmer implements CacheWarmerInterface
         $this->filesystem = $filesystem;
     }
 
-    public function warmUp($cacheDir, string $buildDir = null): array
+    public function warmUp($cacheDir, ?string $buildDir = null): array
     {
         foreach ($this->paths as $path) {
             $this->filesystem->remove($path); // clean previous cache

--- a/src/DependencyInjection/ExerciseHTMLPurifierExtension.php
+++ b/src/DependencyInjection/ExerciseHTMLPurifierExtension.php
@@ -113,7 +113,7 @@ class ExerciseHTMLPurifierExtension extends Extension
         $resolved[$parent]['blank_elements'] = $configs[$parent]['blank_elements'];
     }
 
-    private static function getResolvedConfig(string $parameter, array $parents, array $definition = null): array
+    private static function getResolvedConfig(string $parameter, array $parents, ?array $definition = null): array
     {
         if (null !== $definition) {
             return array_filter(array_merge(

--- a/src/HTMLPurifierConfigFactory.php
+++ b/src/HTMLPurifierConfigFactory.php
@@ -24,7 +24,7 @@ class HTMLPurifierConfigFactory
     public static function create(
         string $profile,
         array $configArray,
-        \HTMLPurifier_Config $defaultConfig = null,
+        ?\HTMLPurifier_Config $defaultConfig = null,
         array $parents = [],
         array $attributes = [],
         array $elements = [],


### PR DESCRIPTION
and get rid of node deprecations warnings like
> The following actions uses node12 which is deprecated and will be forced to run on node16 [...]